### PR TITLE
Partial Fix for issue 1 (build on Mac OSX)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,12 @@ JDBC_CONFIG = jdbc_config
 
 SHLIB_LINK = -ljvm
 
+UNAME = $(shell uname)
+
+ifeq ($(UNAME), Darwin)
+	SHLIB_LINK = -I/System/Library/Frameworks/JavaVM.framework/Headers -L/System/Library/Frameworks/JavaVM.framework/Libraries -ljvm -framework JavaVM
+endif
+
 TRGTS = JAVAFILES
 
 JAVA_SOURCES = \


### PR DESCRIPTION
Hi. I've made some changes on MakeFile to build it on a Mac OSX.

I used "SHLIB_LINK = -I/System/Library/Frameworks/JavaVM.framework/Headers -L/System/Library/Frameworks/JavaVM.framework/Libraries -ljvm -framework JavaVM" instead of only "SHLIB_LINK = -ljvm"  and it worked. It's returning a warning but  is running OK.

The warning: 
ld: warning: ignoring file /System/Library/Frameworks/JavaVM.framework/Libraries/libjvm.dylib, file was built for unsupported file format ( 0xce 0xfa 0xed 0xfe 0x 7 0x 0 0x 0 0x 0 0x 3 0x 0 0x 0 0x 0 0x 6 0x 0 0x 0 0x 0 ) which is not the architecture being linked (x86_64): /System/Library/Frameworks/JavaVM.framework/Libraries/libjvm.dylib

I will try to figure out...

I inserted a condition in Makefile to check the OS kernel and select the correct SHLIB_LINK.

I hope it helps ;)
