### PR TITLE
Work around error in JDBCUtils.java

### DIFF
--- a/JDBCUtils.java
+++ b/JDBCUtils.java
@@ -178,8 +178,14 @@ public class JDBCUtils
 
 		try
 		{
-			result_set.close();
-			conn.close();
+			if (result_set != null)
+			{
+				result_set.close();
+			}
+			if (conn != null)
+			{
+				conn.close();
+			}
 			result_set = null;
 			conn = null;
 			Iterate = null;


### PR DESCRIPTION
This is probably a symptom of something else going wrong, but other people seem to be experiencing it too.  The change should address this:
ERROR:  java.lang.NullPointerException
        at JDBCUtils.Close(JDBCUtils.java:181)