### PR TITLE
Report all Throwable issues, not just Exceptions

### DIFF
--- a/JDBCUtils.java
+++ b/JDBCUtils.java
@@ -113,7 +113,7 @@ public class JDBCUtils
   			NumberOfColumns = result_set_metadata.getColumnCount();
   			Iterate = new String[NumberOfColumns];
 		}
-		catch (Exception initialize_exception)
+		catch (Throwable initialize_exception)
 	  	{
 			/* If an exception occurs,it is returned back to the
 			 * calling C code by returning a Java String object


### PR DESCRIPTION
Errors were not being caught and returned to the C code in postgres, making it difficult to diagnose an issue loading the JDBC driver.  This change allows both Errors and Exceptions to be caught and handled.